### PR TITLE
[CEN-1448] Send transactions to rtd trx queue

### DIFF
--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/event/EventHandler.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/event/EventHandler.java
@@ -28,11 +28,10 @@ public class EventHandler {
    * @return a consumer for Event Grid events.
    */
   @Bean
-  public Consumer<Message<List<EventGridEvent>>> blobStorageConsumer(
-      BlobApplicationAware blobApplicationAware) {
+  public Consumer<Message<List<EventGridEvent>>> blobStorageConsumer() {
     return message -> message.getPayload().stream()
         .filter(e -> "Microsoft.Storage.BlobCreated".equals(e.getEventType()))
-        .map(EventGridEvent::getSubject).map(blobApplicationAware::init)
+        .map(EventGridEvent::getSubject).map(BlobApplicationAware::new)
         .map(blobRestConnector::download).map(blobRestConnector::open)
         .map(blobRestConnector::produce).collect(Collectors.toList());
   }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/event/EventHandler.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/event/EventHandler.java
@@ -1,11 +1,13 @@
 package it.gov.pagopa.rtd.ms.rtdmsingestor.event;
 
+import it.gov.pagopa.rtd.ms.rtdmsingestor.model.BlobApplicationAware;
 import it.gov.pagopa.rtd.ms.rtdmsingestor.model.EventGridEvent;
-import it.gov.pagopa.rtd.ms.rtdmsingestor.service.BlobApplicationAware;
+import it.gov.pagopa.rtd.ms.rtdmsingestor.service.BlobRestConnector;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import lombok.Getter;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.Message;
@@ -16,6 +18,9 @@ import org.springframework.messaging.Message;
 @Configuration
 @Getter
 public class EventHandler {
+
+  @Autowired
+  BlobRestConnector blobRestConnector;
 
   /**
    * Constructor.
@@ -28,8 +33,8 @@ public class EventHandler {
     return message -> message.getPayload().stream()
         .filter(e -> "Microsoft.Storage.BlobCreated".equals(e.getEventType()))
         .map(EventGridEvent::getSubject).map(blobApplicationAware::init)
-        .map(blobApplicationAware::download).map(blobApplicationAware::open)
-        .collect(Collectors.toList());
+        .map(blobRestConnector::download).map(blobRestConnector::open)
+        .map(blobRestConnector::produce).collect(Collectors.toList());
   }
 
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/BlobApplicationAware.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/BlobApplicationAware.java
@@ -1,0 +1,31 @@
+package it.gov.pagopa.rtd.ms.rtdmsingestor.model;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.stream.function.StreamBridge;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.stereotype.Service;
+
+/**
+ * Thi calss represents the mapping of a blob storage to Java object.
+ */
+@NoArgsConstructor
+@Getter
+@Setter
+@Slf4j
+public class BlobApplicationAware {
+
+  String uri;
+
+  public BlobApplicationAware init(String uri) {
+    this.uri = uri;
+    log.info("Init: %s", uri);
+    return this;
+  }
+
+
+}

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/BlobApplicationAware.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/BlobApplicationAware.java
@@ -4,11 +4,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cloud.stream.function.StreamBridge;
-import org.springframework.messaging.Message;
-import org.springframework.messaging.support.MessageBuilder;
-import org.springframework.stereotype.Service;
 
 /**
  * Thi calss represents the mapping of a blob storage to Java object.
@@ -21,10 +16,9 @@ public class BlobApplicationAware {
 
   String uri;
 
-  public BlobApplicationAware init(String uri) {
+  public BlobApplicationAware(String uri) {
     this.uri = uri;
     log.info("Init: %s", uri);
-    return this;
   }
 
 

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/service/BlobRestConnector.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/service/BlobRestConnector.java
@@ -20,12 +20,12 @@ public class BlobRestConnector {
   StreamBridge sb;
 
   public BlobApplicationAware download(BlobApplicationAware blob) {
-    log.info("Init: %s", blob.getUri());
+    log.info("Init: {}", blob.getUri());
     return blob;
   }
 
   public BlobApplicationAware open(BlobApplicationAware blob) {
-    log.info("Open: %s", blob.getUri());
+    log.info("Open: {}", blob.getUri());
     return blob;
   }
 
@@ -36,7 +36,7 @@ public class BlobRestConnector {
    * @return the transaction with the Acquiredr id set to "idtrx".
    */
   public Transaction produce(BlobApplicationAware blob) {
-    log.info("Produce: %s", blob.getUri());
+    log.info("Produce: {}", blob.getUri());
     Transaction t = new Transaction();
     t.setIdTrxAcquirer("idtrx");
     sb.send("rtdTrxProducer-out-0",  MessageBuilder.withPayload(t).build());

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/service/BlobRestConnector.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/service/BlobRestConnector.java
@@ -1,14 +1,17 @@
 package it.gov.pagopa.rtd.ms.rtdmsingestor.service;
 
+import it.gov.pagopa.rtd.ms.rtdmsingestor.model.BlobApplicationAware;
+import it.gov.pagopa.rtd.ms.rtdmsingestor.model.Transaction;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.stream.function.StreamBridge;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.stereotype.Service;
-import it.gov.pagopa.rtd.ms.rtdmsingestor.model.BlobApplicationAware;
-import it.gov.pagopa.rtd.ms.rtdmsingestor.model.Transaction;
-import lombok.extern.slf4j.Slf4j;
 
+/**
+ * This class contains handling methods for blobs.
+ */
 @Service
 @Slf4j
 public class BlobRestConnector {

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/service/BlobRestConnector.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/service/BlobRestConnector.java
@@ -1,35 +1,29 @@
 package it.gov.pagopa.rtd.ms.rtdmsingestor.service;
 
-import it.gov.pagopa.rtd.ms.rtdmsingestor.model.Transaction;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.stream.function.StreamBridge;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.stereotype.Service;
+import it.gov.pagopa.rtd.ms.rtdmsingestor.model.BlobApplicationAware;
+import it.gov.pagopa.rtd.ms.rtdmsingestor.model.Transaction;
+import lombok.extern.slf4j.Slf4j;
 
-/**
- * Thi calss represents the mapping of a blob storage to Java object.
- */
 @Service
 @Slf4j
-public class BlobApplicationAware {
+public class BlobRestConnector {
 
   @Autowired
   StreamBridge sb;
 
-  String uri;
-
-  public BlobApplicationAware init(String uri) {
-    this.uri = uri;
-    return this;
-  }
-
   public BlobApplicationAware download(BlobApplicationAware blob) {
-    return this;
+    log.info("Init: %s", blob.getUri());
+    return blob;
   }
 
   public BlobApplicationAware open(BlobApplicationAware blob) {
-    return this;
+    log.info("Open: %s", blob.getUri());
+    return blob;
   }
 
   /**
@@ -39,8 +33,10 @@ public class BlobApplicationAware {
    * @return the transaction with the Acquiredr id set to "idtrx".
    */
   public Transaction produce(BlobApplicationAware blob) {
+    log.info("Produce: %s", blob.getUri());
     Transaction t = new Transaction();
     t.setIdTrxAcquirer("idtrx");
+    sb.send("rtdTrxProducer-out-0",  MessageBuilder.withPayload(t).build());
     return t;
   }
 

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsingestor/RtdMsIngestorApplicationTests.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsingestor/RtdMsIngestorApplicationTests.java
@@ -9,9 +9,10 @@ import static org.mockito.Mockito.verify;
 
 import it.gov.pagopa.rtd.ms.rtdmsingestor.event.EventHandler;
 import it.gov.pagopa.rtd.ms.rtdmsingestor.event.EventHandlerIntegration;
+import it.gov.pagopa.rtd.ms.rtdmsingestor.model.BlobApplicationAware;
 import it.gov.pagopa.rtd.ms.rtdmsingestor.model.EventGridEvent;
 import it.gov.pagopa.rtd.ms.rtdmsingestor.model.Transaction;
-import it.gov.pagopa.rtd.ms.rtdmsingestor.service.BlobApplicationAware;
+import it.gov.pagopa.rtd.ms.rtdmsingestor.service.BlobRestConnector;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -47,6 +48,9 @@ class RtdMsIngestorApplicationTests {
   @SpyBean
   private BlobApplicationAware blobApplicationAware;
 
+  @SpyBean
+  private BlobRestConnector blobRestConnector;
+
   @Test
   void shouldSendMessageOnRtdQueue() {
     String container = "rtd-transactions-32489876908u74bh781e2db57k098c5ad034341i8u7y";
@@ -77,7 +81,7 @@ class RtdMsIngestorApplicationTests {
 
     await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
 
-      verify(blobApplicationAware, atLeastOnce())
+      verify(blobRestConnector, atLeastOnce())
           .test(ArgumentMatchers.<Message<Transaction>>any());
 
     });

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsingestor/RtdMsIngestorApplicationTests.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsingestor/RtdMsIngestorApplicationTests.java
@@ -2,7 +2,7 @@ package it.gov.pagopa.rtd.ms.rtdmsingestor;
 
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -68,7 +68,7 @@ class RtdMsIngestorApplicationTests {
         stream.send("blobStorageConsumer-in-0", MessageBuilder.withPayload(myList).build()));
 
     await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
-      verify(blobApplicationAware, times(1)).init(anyString());
+      verify(blobRestConnector, times(1)).download(any());
 
     });
   }

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsingestor/event/EventHandlerIntegration.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsingestor/event/EventHandlerIntegration.java
@@ -3,11 +3,13 @@ package it.gov.pagopa.rtd.ms.rtdmsingestor.event;
 import java.util.function.Consumer;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.Message;
+import it.gov.pagopa.rtd.ms.rtdmsingestor.model.BlobApplicationAware;
 import it.gov.pagopa.rtd.ms.rtdmsingestor.model.Transaction;
-import it.gov.pagopa.rtd.ms.rtdmsingestor.service.BlobApplicationAware;
+import it.gov.pagopa.rtd.ms.rtdmsingestor.service.BlobRestConnector;
 
 /**
  * Component defining the processing steps in response to storage events.
@@ -17,11 +19,14 @@ import it.gov.pagopa.rtd.ms.rtdmsingestor.service.BlobApplicationAware;
 @Slf4j
 public class EventHandlerIntegration {
 
+  @Autowired
+  BlobRestConnector blobRestConnector;
+
   @Bean
   public Consumer<Message<Transaction>> rtdTrxConsumer(
       BlobApplicationAware blobApplicationAware) {
     return message -> {
-      blobApplicationAware.test(message);
+      blobRestConnector.test(message);
       log.info("\n\n\n\n\n\nTEST\n\n\n\n\n\n");
     };
   }


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to refactor the Blob Application Aware object to split the model from the service (BlobRestConnector). A basic logic in the appropriate method of the BlobRestConnector is added to test end-to-end the integration with the event hub.

#### List of Changes

<!--- Describe your changes in detail -->
- Refactor BlobApplicationAware
- Add BlobRestConnector Service to manage connections with blob storage
- Refactor Integration tests

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This change are required to test if the microservice is capable of pushing transactions to the rtd-trx queue

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] Unit Test Suite
- [x] Integration Test Suite
- [ ] Api Tests
- [ ] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.