### PR TITLE
[CEN-1449] Implement file receive logic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,16 @@
       <artifactId>lombok</artifactId>
     </dependency>
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.11.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.13</version>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
     </dependency>

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/event/EventHandler.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/event/EventHandler.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,6 +17,7 @@ import org.springframework.messaging.Message;
 /**
  * Component defining the processing steps in response to storage events.
  */
+@Slf4j
 @Configuration
 @Getter
 public class EventHandler {
@@ -45,7 +47,7 @@ public class EventHandler {
   }
 
   public static Object test(Object o) {
-    System.out.println("--OK---");
+    log.info("--OK---");
     return o;
   }
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/event/EventHandler.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/event/EventHandler.java
@@ -1,6 +1,7 @@
 package it.gov.pagopa.rtd.ms.rtdmsingestor.event;
 
 import it.gov.pagopa.rtd.ms.rtdmsingestor.model.BlobApplicationAware;
+import it.gov.pagopa.rtd.ms.rtdmsingestor.model.BlobApplicationAware.Status;
 import it.gov.pagopa.rtd.ms.rtdmsingestor.model.EventGridEvent;
 import it.gov.pagopa.rtd.ms.rtdmsingestor.service.BlobRestConnector;
 import java.util.List;
@@ -32,8 +33,19 @@ public class EventHandler {
     return message -> message.getPayload().stream()
         .filter(e -> "Microsoft.Storage.BlobCreated".equals(e.getEventType()))
         .map(EventGridEvent::getSubject).map(BlobApplicationAware::new)
-        .map(blobRestConnector::download).map(blobRestConnector::open)
-        .map(blobRestConnector::produce).collect(Collectors.toList());
+        .filter(b -> Status.RECEIVED.equals(b.getStatus()))
+        .map(blobRestConnector::download)
+        .filter(b -> Status.DOWNLOADED.equals(b.getStatus()))
+        //.map(blobRestConnector::produce)
+        //.filter(b -> Status.PRODUCED.equals(b.getStatus()))
+        //.map(blobRestConnector::delete)
+        //..filter(b -> Status.DELETED.equals(b.getStatus()))
+        .map(EventHandler::test)
+        .collect(Collectors.toList());
   }
 
+  public static Object test(Object o) {
+    System.out.println("--OK---");
+    return o;
+  }
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/BlobApplicationAware.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/BlobApplicationAware.java
@@ -41,7 +41,6 @@ public class BlobApplicationAware {
       "^.*containers/((rtd)-transactions-[a-z0-9]{44})/blobs/(.*)");
 
   private static final String WRONG_FORMAT_NAME_WARNING_MSG = "Wrong name format:";
-  private static final String CONFLICTING_SERVICE_WARNING_MSG = "Conflicting service in URI:";
   private static final String EVENT_NOT_OF_INTEREST_WARNING_MSG = "Event not of interest:";
 
   private static final String FAIL_FILE_DELETE_WARNING_MSG = "Failed to delete local blob file:";
@@ -66,16 +65,8 @@ public class BlobApplicationAware {
       String[] blobNameTokenized = blob.split("\\.");
 
       if (checkNameFormat(blobNameTokenized)) {
-
-        //Check whether the blob's service matches in path and name,
-        // then assign the target container
-        if (matcher.group(2).equalsIgnoreCase("RTD")
-            && blobNameTokenized[0].equalsIgnoreCase("CSTAR")) {
-          targetContainer = targetContainerRtd;
-          status = Status.RECEIVED;
-        } else {
-          log.warn(CONFLICTING_SERVICE_WARNING_MSG + blobUri);
-        }
+        targetContainer = targetContainerRtd;
+        status = Status.RECEIVED;
       } else {
         log.warn(WRONG_FORMAT_NAME_WARNING_MSG + blobUri);
       }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/BlobApplicationAware.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/BlobApplicationAware.java
@@ -1,5 +1,9 @@
 package it.gov.pagopa.rtd.ms.rtdmsingestor.model;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -14,12 +18,116 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class BlobApplicationAware {
 
-  String uri;
-
-  public BlobApplicationAware(String uri) {
-    this.uri = uri;
-    log.info("Init: %s", uri);
+  /**
+   * File lifecycle statuses.
+   */
+  public enum Status {
+    INIT,
+    RECEIVED,
+    DOWNLOADED,
   }
 
+  private String blobUri;
+  private String container;
+  private String blob;
+  private Status status;
+  private String targetContainer;
+
+  private String targetContainerRtd = "rtd-transactions-decrypted";
+
+  private String targetDir = "/tmp";
+
+  private Pattern uriPattern = Pattern.compile(
+      "^.*containers/((rtd)-transactions-[a-z0-9]{44})/blobs/(.*)");
+
+  private static final String WRONG_FORMAT_NAME_WARNING_MSG = "Wrong name format:";
+  private static final String CONFLICTING_SERVICE_WARNING_MSG = "Conflicting service in URI:";
+  private static final String EVENT_NOT_OF_INTEREST_WARNING_MSG = "Event not of interest:";
+
+  private static final String FAIL_FILE_DELETE_WARNING_MSG = "Failed to delete local blob file:";
+
+  /**
+   * Constructor.
+   *
+   * @param uri the blob URI
+   */
+  public BlobApplicationAware(String uri) {
+    blobUri = uri;
+    status = Status.INIT;
+
+    Matcher matcher = uriPattern.matcher(uri);
+
+    if (matcher.matches()) {
+
+      container = matcher.group(1);
+      blob = matcher.group(3);
+
+      //Tokenized blob name for checking compliance
+      String[] blobNameTokenized = blob.split("\\.");
+
+      if (checkNameFormat(blobNameTokenized)) {
+
+        //Check whether the blob's service matches in path and name,
+        // then assign the target container
+        if (matcher.group(2).equalsIgnoreCase("RTD")
+            && blobNameTokenized[0].equalsIgnoreCase("CSTAR")) {
+          targetContainer = targetContainerRtd;
+          status = Status.RECEIVED;
+        } else {
+          log.warn(CONFLICTING_SERVICE_WARNING_MSG + blobUri);
+        }
+      } else {
+        log.warn(WRONG_FORMAT_NAME_WARNING_MSG + blobUri);
+      }
+    } else {
+      log.info(EVENT_NOT_OF_INTEREST_WARNING_MSG + blobUri);
+    }
+  }
+
+
+  /**
+   * This method matches PagoPA file name's standard Specifics can be found at:
+   * https://docs.pagopa.it/digital-transaction-register/v/digital-transaction-filter/acquirer-integration-with-pagopa-centrostella/integration/standard-pagopa-file-transactions
+   * ADE transactions are excluded here.
+   *
+   * @param uriTokens values obtained from the name of the blob (separated by dots)
+   * @return true if the name matches the format, false otherwise
+   */
+  private boolean checkNameFormat(String[] uriTokens) {
+    // Check for application name (add new services to the regex)
+    if (uriTokens[0] == null || !uriTokens[0].matches("(CSTAR)")) {
+      return false;
+    }
+
+    // Check for sender ABI code
+    if (uriTokens[1] == null || !uriTokens[1].matches("[a-zA-Z0-9]{5}")) {
+      return false;
+    }
+
+    // Check for filetype (fixed "TRNLOG" value)
+    // Should ignore case?
+    if (uriTokens[2] == null || !uriTokens[2].equalsIgnoreCase("TRNLOG")) {
+      return false;
+    }
+
+    // Check for creation timestamp correctness
+    if (uriTokens[3] == null || uriTokens[4] == null) {
+      return false;
+    }
+
+    SimpleDateFormat daysFormat = new SimpleDateFormat("yyyyMMddHHmmss");
+    // Make the format refuse wrong date and time (default behavior is to overflow values in
+    // following date)
+    daysFormat.setLenient(false);
+
+    try {
+      daysFormat.parse(uriTokens[3] + uriTokens[4]);
+    } catch (ParseException e) {
+      return false;
+    }
+
+    // Check for progressive value
+    return (uriTokens[5] != null) && uriTokens[5].matches("[0-9]{3}");
+  }
 
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/service/BlobRestConnector.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/service/BlobRestConnector.java
@@ -2,12 +2,24 @@ package it.gov.pagopa.rtd.ms.rtdmsingestor.service;
 
 import it.gov.pagopa.rtd.ms.rtdmsingestor.model.BlobApplicationAware;
 import it.gov.pagopa.rtd.ms.rtdmsingestor.model.Transaction;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Path;
+import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.message.BasicHeader;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.stream.function.StreamBridge;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StreamUtils;
 
 /**
  * This class contains handling methods for blobs.
@@ -16,16 +28,42 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class BlobRestConnector {
 
+  @Value("${ingestor.api.baseurl}")
+  private String baseUrl;
+
+  @Value("${ingestor.blobclient.apikey}")
+  private String blobApiKey;
+
+  @Value("${ingestor.blobclient.basepath}")
+  private String blobBasePath;
+
+  @Autowired
+  CloseableHttpClient httpClient;
+
   @Autowired
   StreamBridge sb;
 
+  /**
+   * Method that allows the download of the blob from a remote storage.
+   *
+   * @param blob a blob that has been received from the event hub but not downloaded.
+   * @return a locally available blob
+   */
   public BlobApplicationAware download(BlobApplicationAware blob) {
-    log.info("Init: {}", blob.getUri());
-    return blob;
-  }
+    String uri = baseUrl + "/" + blobBasePath + "/" + blob.getContainer() + "/" + blob.getBlob();
+    final HttpGet getBlob = new HttpGet(uri);
+    getBlob.setHeader(new BasicHeader("Ocp-Apim-Subscription-Key", blobApiKey));
 
-  public BlobApplicationAware open(BlobApplicationAware blob) {
-    log.info("Open: {}", blob.getUri());
+    try {
+      OutputStream result = httpClient.execute(getBlob,
+          new FileDownloadResponseHandler(
+              new FileOutputStream(Path.of(blob.getTargetDir(), blob.getBlob()).toFile())));
+      result.close();
+      blob.setStatus(BlobApplicationAware.Status.DOWNLOADED);
+    } catch (Exception ex) {
+      log.error("{}, GET Blob failed:{}", ex, blob.getBlobUri());
+    }
+
     return blob;
   }
 
@@ -36,14 +74,30 @@ public class BlobRestConnector {
    * @return the transaction with the Acquiredr id set to "idtrx".
    */
   public Transaction produce(BlobApplicationAware blob) {
-    log.info("Produce: {}", blob.getUri());
+    log.info("Produce: {}", blob.getBlobUri());
     Transaction t = new Transaction();
     t.setIdTrxAcquirer("idtrx");
-    sb.send("rtdTrxProducer-out-0",  MessageBuilder.withPayload(t).build());
+    sb.send("rtdTrxProducer-out-0", MessageBuilder.withPayload(t).build());
     return t;
   }
 
   public void test(Message<Transaction> t) {
     log.info("\n" + t.getPayload().getIdTrxAcquirer() + "\n");
+  }
+
+  static class FileDownloadResponseHandler implements ResponseHandler<OutputStream> {
+
+    private final OutputStream target;
+
+    public FileDownloadResponseHandler(OutputStream target) {
+      this.target = target;
+    }
+
+    @Override
+    public OutputStream handleResponse(HttpResponse response) throws IOException {
+      StreamUtils.copy(Objects.requireNonNull(response.getEntity().getContent()), this.target);
+      return this.target;
+    }
+
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,9 @@ logging:
     root: INFO
 
 ingestor:
+  resources:
+    base:
+      path: src/test/resources
   api:
     baseurl: https://${CSV_INGESTOR_HOST:internal.it}
   blobclient:

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsingestor/event/EventHandlerIntegration.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsingestor/event/EventHandlerIntegration.java
@@ -1,5 +1,7 @@
 package it.gov.pagopa.rtd.ms.rtdmsingestor.event;
 
+import it.gov.pagopa.rtd.ms.rtdmsingestor.model.Transaction;
+import it.gov.pagopa.rtd.ms.rtdmsingestor.service.BlobRestConnector;
 import java.util.function.Consumer;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -7,9 +9,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.Message;
-import it.gov.pagopa.rtd.ms.rtdmsingestor.model.BlobApplicationAware;
-import it.gov.pagopa.rtd.ms.rtdmsingestor.model.Transaction;
-import it.gov.pagopa.rtd.ms.rtdmsingestor.service.BlobRestConnector;
 
 /**
  * Component defining the processing steps in response to storage events.
@@ -22,9 +21,13 @@ public class EventHandlerIntegration {
   @Autowired
   BlobRestConnector blobRestConnector;
 
+  /**
+   * Event handler triggered by the insertion of a transaction on the input queue.
+   *
+   * @return a consumer handling events.
+   */
   @Bean
-  public Consumer<Message<Transaction>> rtdTrxConsumer(
-      BlobApplicationAware blobApplicationAware) {
+  public Consumer<Message<Transaction>> rtdTrxConsumer() {
     return message -> {
       blobRestConnector.test(message);
       log.info("\n\n\n\n\n\nTEST\n\n\n\n\n\n");

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/BlobApplicationAwareTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/BlobApplicationAwareTest.java
@@ -1,0 +1,80 @@
+package it.gov.pagopa.rtd.ms.rtdmsingestor.model;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import it.gov.pagopa.rtd.ms.rtdmsingestor.model.BlobApplicationAware.Status;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+
+@SpringBootTest
+@ExtendWith(OutputCaptureExtension.class)
+class BlobApplicationAwareTest {
+
+  @Value("${ingestor.resources.base.path}")
+  String resources;
+
+  @MockBean
+  CloseableHttpClient closeableHttpClient;
+
+  @Test
+  void shouldMatchRegexRtd() {
+    String container = "rtd-transactions-32489876908u74bh781e2db57k098c5ad034341i8u7y";
+    String blob = "CSTAR.99910.TRNLOG.20220228.103107.001.csv.pgp";
+    String blobUri = "/blobServices/default/containers/" + container + "/blobs/" + blob;
+    BlobApplicationAware myBlob = new BlobApplicationAware(blobUri);
+    assertSame(Status.RECEIVED, myBlob.getStatus());
+  }
+
+  @Test
+  void shouldNotMatchRegexEventNotOfInterest(CapturedOutput output) {
+    String container = "ade-transactions-32489876908u74bh781e2db57k098c5ad034341i8u7y";
+    String blob = "ADE.99910.TRNLOG.20220228.203107.001.csv.pgp";
+    String blobUri = "/blobServices/default/containers/" + container + "/blobs/" + blob;
+    BlobApplicationAware myBlob = new BlobApplicationAware(blobUri);
+    assertSame(Status.INIT, myBlob.getStatus());
+    assertThat(output.getOut(), containsString("Event not of interest:"));
+  }
+
+  @Test
+  void shouldNotMatchRegexConflictAppAndName() {
+    String container = "rtd-transactions-32489876908u74bh781e2db57k098c5ad034341i8u7y";
+    String blob = "ADE.99910.TRNLOG.20220228.203107.001.csv.pgp";
+    String blobUri = "/blobServices/default/containers/" + container + "/blobs/" + blob;
+    BlobApplicationAware myBlob = new BlobApplicationAware(blobUri);
+    assertSame(Status.INIT, myBlob.getStatus());
+  }
+
+
+  //The test parameters reproduce the following scenarios: blobUriShouldFailWrongService,
+  // blobUriShouldFailNoService, blobUriShouldFailShortABI, blobUriShouldFailLongABI,
+  // blobUriShouldFailNoABI, blobUriShouldFailWrongFiletype, blobUriShouldFailNoFiletype,
+  // blobUriShouldFailWrongDate, blobUriShouldFailNoDate, blobUriShouldFailWrongTime,
+  // blobUriShouldFailNoTime, blobUriShouldFailWrongProgressive,
+  // blobUriShouldFailNoProgressive
+  @ParameterizedTest
+  @ValueSource(strings = {"CSTA.99910.TRNLOG.20220228.203107.001.csv.pgp",
+      ".99910.TRNLOG.20220228.203107.001.csv.pgp", "CSTAR.9991.TRNLOG.20220228.203107.001.csv.pgp",
+      "CSTAR.999100.TRNLOG.20220228.203107.999.csv.pgp",
+      "CSTAR..TRNLOG.20220228.203107.001.csv.pgp", "CSTAR.99910.TRNLO.20220228.203107.001.csv.pgp",
+      "CSTAR.99910..20220228.203107.001.csv.pgp", "CSTAR.99910.TRNLOG.20220230.103107.001.csv.pgp",
+      "CSTAR.99910.TRNLOG..103107.001.csv.pgp", "CSTAR.99910.TRNLOG.20220228.243107.001.csv.pgp",
+      "CSTAR.99910.TRNLOG.20220228..001.csv.pgp", "CSTAR.99910.TRNLOG.20220228.103107.1.csv.pgp",
+      "CSTAR.99910.TRNLOG.20220228.103107..csv.pgp"})
+  void blobUriShouldFailRegex(String blobName, CapturedOutput output) {
+    String container = "rtd-transactions-32489876908u74bh781e2db57k098c5ad034341i8u7y";
+    String blobUri = "/blobServices/default/containers/" + container + "/blobs/" + blobName;
+    BlobApplicationAware myBlob = new BlobApplicationAware(blobUri);
+    assertSame(Status.INIT, myBlob.getStatus());
+  }
+
+}

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsingestor/service/BlobRestConnectorTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsingestor/service/BlobRestConnectorTest.java
@@ -91,9 +91,11 @@ class BlobRestConnectorTest {
     assertThat(output.getOut(), containsString("GET Blob failed"));
   }
 
+  //This test is temporary
   @Test
   void shouldProduce(CapturedOutput output) {
     blobRestConnector.produce(blobIn);
+    assertThat(output.getOut(), containsString("Produce:"));
   }
 
 }

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsingestor/service/BlobRestConnectorTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsingestor/service/BlobRestConnectorTest.java
@@ -1,0 +1,99 @@
+package it.gov.pagopa.rtd.ms.rtdmsingestor.service;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import it.gov.pagopa.rtd.ms.rtdmsingestor.event.EventHandlerIntegration;
+import it.gov.pagopa.rtd.ms.rtdmsingestor.model.BlobApplicationAware;
+import java.io.IOException;
+import java.io.OutputStream;
+import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.context.ActiveProfiles;
+
+
+@SpringBootTest
+@ActiveProfiles("test")
+@EmbeddedKafka(topics = {
+    "rtd-platform-events"}, partitions = 1,
+    bootstrapServersProperty = "spring.cloud.stream.kafka.binder.brokers")
+@ExtendWith(OutputCaptureExtension.class)
+class BlobRestConnectorTest {
+
+  @Autowired
+  BlobRestConnector blobRestConnector;
+
+  @MockBean
+  CloseableHttpClient client;
+
+  @Autowired
+  EventHandlerIntegration eventHandlerIntegration;
+
+  private final String container = "rtd-transactions-32489876908u74bh781e2db57k098c5ad034341i8u7y";
+  private final String blobName = "CSTAR.99910.TRNLOG.20220228.103107.001.csv.pgp";
+
+  private BlobApplicationAware blobIn;
+
+  @BeforeEach
+  public void setUp() {
+    blobIn = new BlobApplicationAware(
+        "/blobServices/default/containers/" + container + "/blobs/" + blobName);
+  }
+
+  @Test
+  void shouldDownload(CapturedOutput output) throws IOException {
+    // Improvement idea: mock all the stuff needed in order to allow the FileDownloadResponseHandler
+    // class to create a file in a temporary directory and test the content of the downloaded file
+    // for an expected content.
+    OutputStream mockedOutputStream = mock(OutputStream.class);
+    doReturn(mockedOutputStream).when(client)
+        .execute(any(HttpGet.class), any(BlobRestConnector.FileDownloadResponseHandler.class));
+
+    BlobApplicationAware blobOut = blobRestConnector.download(blobIn);
+
+    verify(client, times(1)).execute(any(HttpUriRequest.class),
+        ArgumentMatchers.<ResponseHandler<OutputStream>>any());
+    assertEquals(BlobApplicationAware.Status.DOWNLOADED, blobOut.getStatus());
+    assertThat(output.getOut(), not(containsString("GET Blob failed")));
+  }
+
+
+  @Test
+  void shouldFailDownload(CapturedOutput output) throws IOException {
+    doThrow(IOException.class).when(client)
+        .execute(any(HttpGet.class), any(BlobRestConnector.FileDownloadResponseHandler.class));
+
+    BlobApplicationAware blobOut = blobRestConnector.download(blobIn);
+
+    verify(client, times(1)).execute(any(HttpUriRequest.class),
+        ArgumentMatchers.<ResponseHandler<OutputStream>>any());
+    assertEquals(BlobApplicationAware.Status.RECEIVED, blobOut.getStatus());
+    assertThat(output.getOut(), containsString("GET Blob failed"));
+  }
+
+  @Test
+  void shouldProduce(CapturedOutput output) {
+    blobRestConnector.produce(blobIn);
+  }
+
+}


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR implement the download logic, allowing the download of a blob file upon receiving an input event.
#### List of Changes

<!--- Describe your changes in detail -->
- Enriched the event handler.
- Defined the constructor of the BlobApplicationAware, implementing pattern matching for name convention correctness.
- Implement download logic in BlobRestConnector.
- Unit tests for each component introduced.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The blob, after its initialization, must be downloaded from remote.
This step is necessary in order to parse the file and send the transactions.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Api Tests
- [ ] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.