### PR TITLE
[CEN-1553] Implement remote delete method for blobs.

### DIFF
--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/BlobApplicationAware.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/BlobApplicationAware.java
@@ -26,6 +26,7 @@ public class BlobApplicationAware {
     RECEIVED,
     DOWNLOADED,
     PROCESSED,
+    REMOTELY_DELETED,
   }
 
   private String blobUri;


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR implements the remote deletion of the processed blob.
A DELETE HTTP call to the blob URI is done in order to achieve this.
#### List of Changes

<!--- Describe your changes in detail -->
- Add the REMOTELY_DELETED status for blobs.
- Add remote deletion mechanism.
- Add unit tests.
#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
After a successful processing, the blob is useless so a mechanism for deleting it remotely (anche locally) was needed.
#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Api Tests
- [ ] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.