### PR TITLE
[RTD-984] increase sonarcloud coverage

### DIFF
--- a/google_checks.xml
+++ b/google_checks.xml
@@ -211,7 +211,7 @@
              value="Pattern variable name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="ClassTypeParameterName">
-      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+      <property name="format" value="(^[A-Z]\\d?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
       <message key="name.invalidPattern"
              value="Class type name ''{0}'' must match pattern ''{1}''."/>
     </module>
@@ -221,17 +221,17 @@
                value="Record component name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="RecordTypeParameterName">
-      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+      <property name="format" value="(^[A-Z]\\d?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
       <message key="name.invalidPattern"
                value="Record type name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="MethodTypeParameterName">
-      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+      <property name="format" value="(^[A-Z]\\d?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
       <message key="name.invalidPattern"
              value="Method type name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="InterfaceTypeParameterName">
-      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+      <property name="format" value="(^[A-Z]\\d?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
       <message key="name.invalidPattern"
              value="Interface type name ''{0}'' must match pattern ''{1}''."/>
     </module>

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/BlobApplicationAware.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/BlobApplicationAware.java
@@ -94,27 +94,22 @@ public class BlobApplicationAware {
   private boolean checkNameFormat(String[] uriTokens) {
 
     //Check if the tokens length is right
-    if( uriTokens.length < 8) {
+    if( uriTokens.length < 6 ) {
       return false;
     }
     // Check for application name (add new services to the regex)
-    if ( !uriTokens[0].matches("(CSTAR)")) {
+    if ( !uriTokens[0].matches("(CSTAR)" )) {
       return false;
     }
 
     // Check for sender ABI code
-    if ( !uriTokens[1].matches("[a-zA-Z0-9]{5}")) {
+    if ( !uriTokens[1].matches("[a-zA-Z0-9]{5}") ) {
       return false;
     }
 
     // Check for filetype (fixed "TRNLOG" value)
     // Should ignore case?
-    if ( !uriTokens[2].equalsIgnoreCase("TRNLOG")) {
-      return false;
-    }
-
-    // Check for creation timestamp correctness
-    if ( uriTokens[3].matches("\\d{8}") || uriTokens[4].matches("\\d{6}") ) {
+    if ( !uriTokens[2].equalsIgnoreCase("TRNLOG") ) {
       return false;
     }
 

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/BlobApplicationAware.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/BlobApplicationAware.java
@@ -125,7 +125,7 @@ public class BlobApplicationAware {
     }
 
     // Check for progressive value
-    return (uriTokens[5] != null) && uriTokens[5].matches("[0-9]{3}");
+    return (uriTokens[5] != null) && uriTokens[5].matches("\\d{3}");
   }
 
   /**
@@ -134,7 +134,7 @@ public class BlobApplicationAware {
   public BlobApplicationAware localCleanup() {
 
     boolean failCleanup = false;
-    
+
     for (File f : Objects.requireNonNull(Path.of(this.targetDir).toFile().listFiles())) {
       //Delete every file in the temporary directory that starts with the name of the blob.
       if (f.getName().startsWith(blob)) {

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/BlobApplicationAware.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/BlobApplicationAware.java
@@ -92,26 +92,32 @@ public class BlobApplicationAware {
    * @return true if the name matches the format, false otherwise
    */
   private boolean checkNameFormat(String[] uriTokens) {
+
+    //Check if the tokens length is right
+    if( uriTokens.length < 8) {
+      return false;
+    }
     // Check for application name (add new services to the regex)
-    if (uriTokens[0].equals("") || !uriTokens[0].matches("(CSTAR)")) {
+    if ( uriTokens[0].equals("") || !uriTokens[0].matches("(CSTAR)")) {
       return false;
     }
 
     // Check for sender ABI code
-    if (uriTokens[1].equals("") || !uriTokens[1].matches("[a-zA-Z0-9]{5}")) {
+    if ( uriTokens[1] == null || !uriTokens[1].matches("[a-zA-Z0-9]{5}")) {
       return false;
     }
 
     // Check for filetype (fixed "TRNLOG" value)
     // Should ignore case?
-    if (uriTokens[2].equals("") || !uriTokens[2].equalsIgnoreCase("TRNLOG")) {
+    if (uriTokens[2] == null || !uriTokens[2].equalsIgnoreCase("TRNLOG")) {
       return false;
     }
 
     // Check for creation timestamp correctness
-    if (uriTokens[3].equals("") || uriTokens[4].equals("")) {
+    if ( uriTokens[3] == null || uriTokens[4] == null ) {
       return false;
     }
+
     SimpleDateFormat daysFormat = new SimpleDateFormat("yyyyMMddHHmmss");
     // Make the format refuse wrong date and time (default behavior is to overflow values in
     // following date)
@@ -124,7 +130,7 @@ public class BlobApplicationAware {
     }
 
     // Check for progressive value
-    return (!uriTokens[5].equals("")) && uriTokens[5].matches("\\d{3}");
+    return (uriTokens[5] != null) && uriTokens[5].matches("\\d{3}");
   }
 
   /**

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/BlobApplicationAware.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/BlobApplicationAware.java
@@ -97,8 +97,9 @@ public class BlobApplicationAware {
     if( uriTokens.length < 6 ) {
       return false;
     }
+
     // Check for application name (add new services to the regex)
-    if ( !uriTokens[0].matches("(CSTAR)" )) {
+    if ( !uriTokens[0].matches("(CSTAR)") ) {
       return false;
     }
 

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/BlobApplicationAware.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/BlobApplicationAware.java
@@ -98,23 +98,23 @@ public class BlobApplicationAware {
       return false;
     }
     // Check for application name (add new services to the regex)
-    if ( uriTokens[0].equals("") || !uriTokens[0].matches("(CSTAR)")) {
+    if (!uriTokens[0].matches("(CSTAR)")) {
       return false;
     }
 
     // Check for sender ABI code
-    if ( uriTokens[1] == null || !uriTokens[1].matches("[a-zA-Z0-9]{5}")) {
+    if (!uriTokens[1].matches("[a-zA-Z0-9]{5}")) {
       return false;
     }
 
     // Check for filetype (fixed "TRNLOG" value)
     // Should ignore case?
-    if (uriTokens[2] == null || !uriTokens[2].equalsIgnoreCase("TRNLOG")) {
+    if (!uriTokens[2].equalsIgnoreCase("TRNLOG")) {
       return false;
     }
 
     // Check for creation timestamp correctness
-    if ( uriTokens[3] == null || uriTokens[4] == null ) {
+    if ( uriTokens[3].matches("\\d{8}") || uriTokens[4].matches("\\d{6}") ) {
       return false;
     }
 
@@ -130,7 +130,7 @@ public class BlobApplicationAware {
     }
 
     // Check for progressive value
-    return (uriTokens[5] != null) && uriTokens[5].matches("\\d{3}");
+    return uriTokens[5].matches("\\d{3}");
   }
 
   /**

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/BlobApplicationAware.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/BlobApplicationAware.java
@@ -93,26 +93,25 @@ public class BlobApplicationAware {
    */
   private boolean checkNameFormat(String[] uriTokens) {
     // Check for application name (add new services to the regex)
-    if (uriTokens[0] == null || !uriTokens[0].matches("(CSTAR)")) {
+    if (uriTokens[0].equals("") || !uriTokens[0].matches("(CSTAR)")) {
       return false;
     }
 
     // Check for sender ABI code
-    if (uriTokens[1] == null || !uriTokens[1].matches("[a-zA-Z0-9]{5}")) {
+    if (uriTokens[1].equals("") || !uriTokens[1].matches("[a-zA-Z0-9]{5}")) {
       return false;
     }
 
     // Check for filetype (fixed "TRNLOG" value)
     // Should ignore case?
-    if (uriTokens[2] == null || !uriTokens[2].equalsIgnoreCase("TRNLOG")) {
+    if (uriTokens[2].equals("") || !uriTokens[2].equalsIgnoreCase("TRNLOG")) {
       return false;
     }
 
     // Check for creation timestamp correctness
-    if (uriTokens[3] == null || uriTokens[4] == null) {
+    if (uriTokens[3].equals("") || uriTokens[4].equals("")) {
       return false;
     }
-
     SimpleDateFormat daysFormat = new SimpleDateFormat("yyyyMMddHHmmss");
     // Make the format refuse wrong date and time (default behavior is to overflow values in
     // following date)
@@ -125,7 +124,7 @@ public class BlobApplicationAware {
     }
 
     // Check for progressive value
-    return (uriTokens[5] != null) && uriTokens[5].matches("\\d{3}");
+    return (!uriTokens[5].equals("")) && uriTokens[5].matches("\\d{3}");
   }
 
   /**

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/BlobApplicationAware.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/BlobApplicationAware.java
@@ -98,18 +98,18 @@ public class BlobApplicationAware {
       return false;
     }
     // Check for application name (add new services to the regex)
-    if (!uriTokens[0].matches("(CSTAR)")) {
+    if ( !uriTokens[0].matches("(CSTAR)")) {
       return false;
     }
 
     // Check for sender ABI code
-    if (!uriTokens[1].matches("[a-zA-Z0-9]{5}")) {
+    if ( !uriTokens[1].matches("[a-zA-Z0-9]{5}")) {
       return false;
     }
 
     // Check for filetype (fixed "TRNLOG" value)
     // Should ignore case?
-    if (!uriTokens[2].equalsIgnoreCase("TRNLOG")) {
+    if ( !uriTokens[2].equalsIgnoreCase("TRNLOG")) {
       return false;
     }
 

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/FiscalCode.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/FiscalCode.java
@@ -59,7 +59,7 @@ public class FiscalCode {
     boolean[] homocode = new boolean[3];
 
     if (!cf.matches(
-        "^[A-Z]{6}[0-9]{2}[ABCDEHLMPRST]{1}[0-9]{2}[A-Z]{1}[0-9LMNPQRSTUV]{3}[A-Z]{1}$")) {
+        "^[A-Z]{6}\\d{2}[ABCDEHLMPRST]{1}\\d{2}[A-Z]{1}[0-9LMNPQRSTUV]{3}\\d{1}$")) {
       return Response.INVALID_CHARACTERS;
     }
     int s = 0;
@@ -105,7 +105,7 @@ public class FiscalCode {
    * @return Null if valid, or string describing why this CF must be rejected.
    */
   private static Response validateTemporary(String cf) {
-    if (!cf.matches("^[0-9]{11}$")) {
+    if (!cf.matches("^\\d{11}$")) {
       return Response.INVALID_CHARACTERS;
     }
     int s = 0;

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/FiscalCode.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/FiscalCode.java
@@ -66,6 +66,7 @@ public class FiscalCode {
     String evenMap = "BAFHJNPRTVCESULDGIMOQKWZYX";
     for (int i = 0; i < 15; i++) {
       int c = cf.charAt(i);
+      int n;
 
       if (i >= 12) {
         if (String.valueOf(cf.charAt(i)).matches("[LMN]")) {
@@ -79,7 +80,6 @@ public class FiscalCode {
         }
       }
 
-      int n;
       if ('0' <= c && c <= '9') {
         n = c - '0';
       } else {

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/FiscalCode.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/FiscalCode.java
@@ -59,7 +59,7 @@ public class FiscalCode {
     boolean[] homocode = new boolean[3];
 
     if (!cf.matches(
-        "^[A-Z]{6}\\d{2}[ABCDEHLMPRST]\\d{2}[A-Z][0-9LMNPQRSTUV]{3}\\d$")) {
+        "^[A-Z]{6}\\d{2}[ABCDEHLMPRST]\\d{2}[0-9A-Z]{4}[LMNPQRSTUV]$")) {
       return Response.INVALID_CHARACTERS;
     }
     int s = 0;
@@ -68,17 +68,16 @@ public class FiscalCode {
       int c = cf.charAt(i);
       int n;
 
-      if (i >= 12) {
-        if (String.valueOf(cf.charAt(i)).matches("[LMN]")) {
-          c = cf.charAt(i) - 'L' + '0';
-          homocode[i - 12] = true;
-        }
-        //The substitution characters skips the O
-        if (String.valueOf(cf.charAt(i)).matches("[PQRSTUV]")) {
-          c = cf.charAt(i) - 'L' - 1 + '0';
-          homocode[i - 12] = true;
-        }
+      if ((i >= 12) && String.valueOf(cf.charAt(i)).matches("[LMN]")) {
+        c = cf.charAt(i) - 'L' + '0';
+        homocode[i - 12] = true;
       }
+      //The substitution characters skips the O
+      if ((i >= 12) && String.valueOf(cf.charAt(i)).matches("[PQRSTUV]")) {
+        c = cf.charAt(i) - 'L' - 1 + '0';
+        homocode[i - 12] = true;
+      }
+
 
       if ('0' <= c && c <= '9') {
         n = c - '0';

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/FiscalCode.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/FiscalCode.java
@@ -59,7 +59,7 @@ public class FiscalCode {
     boolean[] homocode = new boolean[3];
 
     if (!cf.matches(
-        "^[A-Z]{6}\\d{2}[ABCDEHLMPRST]{1}\\d{2}[A-Z]{1}[0-9LMNPQRSTUV]{3}\\d{1}$")) {
+        "^[A-Z]{6}\\d{2}[ABCDEHLMPRST]\\d{2}[A-Z][0-9LMNPQRSTUV]{3}\\d$")) {
       return Response.INVALID_CHARACTERS;
     }
     int s = 0;

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/Transaction.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/Transaction.java
@@ -38,14 +38,14 @@ public class Transaction {
   @NotNull
   @NotBlank
   @CsvBindByPosition(position = 1)
-  @Pattern(regexp = "[0-9]{2}", message = "Operation type length must match [0-9]{2}")
+  @Pattern(regexp = "\\d{2}", message = "Operation type length must match \\d{2}")
   @JsonProperty(value = "operationType", required = true)
   String operationType;
 
   @NotNull
   @NotBlank
   @CsvBindByPosition(position = 2)
-  @Pattern(regexp = "[0-9]{2}", message = "Circuit type length must match [0-9]{2}")
+  @Pattern(regexp = "\\d{2}", message = "Circuit type length must match \\d{2}")
   String circuitType;
 
   @NotNull
@@ -117,8 +117,8 @@ public class Transaction {
   @NotNull
   @NotBlank
   @CsvBindByPosition(position = 13)
-  @Pattern(regexp = "[0-9]{6}|[0-9]{8}",
-      message = "BIN length must match [0-9]{6}|[0-9]{8}")
+  @Pattern(regexp = "\\d{6}|\\d{8}",
+      message = "BIN length must match \\d{6}|\\d{8}")
   String bin;
 
   @NotNull
@@ -139,7 +139,7 @@ public class Transaction {
   @NotNull
   @NotBlank
   @CsvBindByPosition(position = 17)
-  @Pattern(regexp = "[0-9]{2}", message = "Pos type must match [0-9]{2}")
+  @Pattern(regexp = "\\d{2}", message = "Pos type must match \\d{2}")
   String posType;
 
   @CsvBindByPosition(position = 18)

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/BlobApplicationAwareTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/BlobApplicationAwareTest.java
@@ -105,7 +105,8 @@ class BlobApplicationAwareTest {
       "CSTAR..TRNLOG.20220228.203107.001.csv.pgp", "CSTAR.99910.TRNLO.20220228.203107.001.csv.pgp",
       "CSTAR.99910..20220228.203107.001.csv.pgp", "CSTAR.99910.TRNLOG.20220230.103107.001.csv.pgp",
       "CSTAR.99910.TRNLOG..103107.001.csv.pgp", "CSTAR.99910.TRNLOG.20220228.243107.001.csv.pgp",
-      "CSTAR.99910.TRNLOG.20220228..001.csv.pgp", "CSTAR.99910.TRNLOG.20220228.103107.1.csv.pgp",
+      "CSTAR.99910.TRNLOG.20220228..001.csv.pgp","CSTAR.99910.TRNLOG...001.csv.pgp",
+      "CSTAR.99910.TRNLOG.20220228.103107.1.csv.pgp",
       "CSTAR.99910.TRNLOG.20220228.103107..csv.pgp"})
   void blobUriShouldFailRegex(String blobName, CapturedOutput output) {
     String blobUri = "/blobServices/default/containers/" + containerRtd + "/blobs/" + blobName;

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/BlobApplicationAwareTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsingestor/model/BlobApplicationAwareTest.java
@@ -106,7 +106,8 @@ class BlobApplicationAwareTest {
       "CSTAR.99910..20220228.203107.001.csv.pgp", "CSTAR.99910.TRNLOG.20220230.103107.001.csv.pgp",
       "CSTAR.99910.TRNLOG..103107.001.csv.pgp", "CSTAR.99910.TRNLOG.20220228.243107.001.csv.pgp",
       "CSTAR.99910.TRNLOG.20220228..001.csv.pgp","CSTAR.99910.TRNLOG...001.csv.pgp",
-      "CSTAR.99910.TRNLOG.20220228.103107.1.csv.pgp",
+      "CSTAR.99910.TRNLOG.20220228.103107.1.csv.pgp","","CSTAR","CSTAR.99910",
+      "CSTAR.99910.TRNLOG","CSTAR.99910.TRNLOG.20220228","CSTAR.99910.TRNLOG.20220228.103107",
       "CSTAR.99910.TRNLOG.20220228.103107..csv.pgp"})
   void blobUriShouldFailRegex(String blobName, CapturedOutput output) {
     String blobUri = "/blobServices/default/containers/" + containerRtd + "/blobs/" + blobName;


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
The purpose of this pr was to  increase the sonarcloud coverage from 87% to 100% and to fix all the code smell.

#### List of Changes

1. Change regex number finder from [0-9] to \\d
2. Class BlobApplicationAware: added uriTokens[] length check, deleted controls of null element for each uriTokens[] element because now this will be checked by the previous control (uriTokens[] length > 6 ).  The idea is, that if the uri string has a correct length we just need to check that all the fields are what we are waiting for. 
3. Add some test strings to blobUriShouldFailRegex Test 
4. Class FiscalCode: split a nested if statement into two to make code more readable. ( We assume that this class will be deprecated later)

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Api Tests
- [ ] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.